### PR TITLE
fix: updated filter for sermon series and expired content

### DIFF
--- a/apollos-church-api/src/data/ContentItem.js
+++ b/apollos-church-api/src/data/ContentItem.js
@@ -14,7 +14,7 @@ class dataSource extends ContentItem.dataSource {
       .split(/[-+]\d+:\d+/)[0];
     // the only difference between this and core is that this only looks
     // at startdatetime. Sermon Messages have fake expire dates, so we ignore those.
-    const filter = `((StartDateTime lt datetime'${date}') or (StartDateTime eq null)) and ((Status eq 'Approved') or (ContentChannel/RequiresApproval eq false))`;
+    const filter = `((StartDateTime lt datetime'${date}') or (StartDateTime eq null)) and ((Status eq 'Approved') or (ContentChannel/RequiresApproval eq false)) and ((ContentChannelId eq 22) or (ExpireDateTime gt datetime'${date}') or (ExpireDateTime eq null))`;
     return filter;
   };
 


### PR DESCRIPTION
Tested against the Sermon Series channel (22) and the Weekly Challenges channel (364). Previously Weekly challenges were not falling off if they expired, so that channel was only taking into account priority. With this fix, all content is still appearing in the app as before, but all content channels (except sermon series) are taking into account expiration dates.

<img width="1421" alt="Screen Shot 2021-09-21 at 9 23 20 AM" src="https://user-images.githubusercontent.com/72768221/134191145-7da9f1af-ab1b-40ba-a283-93fef750166c.png">

https://user-images.githubusercontent.com/72768221/134191157-a0712aad-c807-4543-a493-3bdf55c53d5b.mp4