### PR TITLE
fix: Programmatically switch between videos based on live date

### DIFF
--- a/apollos-church-api/package.json
+++ b/apollos-church-api/package.json
@@ -36,6 +36,7 @@
     "apollo-server": "^2.24.1",
     "apollo-server-express": "2.14.2",
     "color": "3.0.0",
+    "date-fns": "^2.24.0",
     "dotenv": "6.0.0",
     "express": "^4.17.0",
     "graphql": "14.6.0",

--- a/apollos-church-api/package.json
+++ b/apollos-church-api/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "setup": "./scripts/init.sh",
     "start": "NODE_ENV=production node ./lib/index.js",
+    "migrator": "node ./lib/migrator.js",
     "start:dev": "linkemon ./src/index.js --exec babel-node --delay 2 -e js,yaml,json,yml",
     "postinstall": "yarn build",
     "build": "NODE_ENV=production rm -rf ./lib && mkdir -p lib && babel ./src -d ./lib",

--- a/apollos-church-api/src/data/ContentItem.js
+++ b/apollos-church-api/src/data/ContentItem.js
@@ -1,5 +1,6 @@
 import { ContentItem } from '@apollosproject/data-connector-rock';
 import moment from 'moment';
+import { isThisWeek } from 'date-fns';
 import ApollosConfig from '@apollosproject/config';
 
 const { ROCK } = ApollosConfig;
@@ -42,25 +43,29 @@ class dataSource extends ContentItem.dataSource {
     return features;
   };
 
-  // This needs to be made async
-  getVideos = ({ attributeValues, attributes }) => {
-    const videoKeys = Object.keys(attributes).filter((key) =>
+  getVideos = (item) => {
+    const startDate = item.startDateTime;
+    // console.log('Is this week? ', isThisWeek(new Date(startDate)));
+    const videoKeys = Object.keys(item.attributes).filter((key) =>
       this.attributeIsVideo({
         key,
-        attributeValues,
-        attributes,
+        attributeValues: item.attributeValues,
+        attributes: item.attributes,
       })
     );
-    // console.log("Full Video", attributeValues?.fullLengthVideoEmbed.value, "Short Video", attributeValues?.videoEmbed.value)
+    // console.log("Full Video", item.attributeValues?.fullLengthVideoEmbed?.value, "Short Video", item.attributeValues?.videoEmbed?.value)
     return videoKeys.map((key) => ({
       __typename: 'VideoMedia',
       key,
-      name: attributes?.key?.name,
-      embedHtml: attributeValues?.key?.value,
-      sources: attributeValues?.key?.value
+      name: item.attributes?.key?.name,
+      embedHtml: isThisWeek(new Date(startDate))
+        ? item.attributeValues?.fullLengthVideoEmbed?.value ||
+          item.attributeValues?.key?.value
+        : item.attributeValues?.key?.value,
+      sources: item.attributeValues?.key?.value
         ? [
             {
-              uri: attributeValues?.key?.value,
+              uri: item.attributeValues?.key?.value,
             },
           ]
         : [],

--- a/apollos-church-api/src/data/ContentItem.js
+++ b/apollos-church-api/src/data/ContentItem.js
@@ -42,6 +42,31 @@ class dataSource extends ContentItem.dataSource {
     return features;
   };
 
+  // This needs to be made async
+  getVideos = ({ attributeValues, attributes }) => {
+    const videoKeys = Object.keys(attributes).filter((key) =>
+      this.attributeIsVideo({
+        key,
+        attributeValues,
+        attributes,
+      })
+    );
+    // console.log("Full Video", attributeValues?.fullLengthVideoEmbed.value, "Short Video", attributeValues?.videoEmbed.value)
+    return videoKeys.map((key) => ({
+      __typename: 'VideoMedia',
+      key,
+      name: attributes?.key?.name,
+      embedHtml: attributeValues?.key?.value,
+      sources: attributeValues?.key?.value
+        ? [
+            {
+              uri: attributeValues?.key?.value,
+            },
+          ]
+        : [],
+    }));
+  };
+
   byTaggedContent = async (tag) => {
     if (!tag) return this.request().empty();
 

--- a/apollos-church-api/src/data/ContentItem.js
+++ b/apollos-church-api/src/data/ContentItem.js
@@ -43,33 +43,33 @@ class dataSource extends ContentItem.dataSource {
     return features;
   };
 
-  getVideos = (item) => {
-    const startDate = item.startDateTime;
-    // console.log('Is this week? ', isThisWeek(new Date(startDate)));
-    const videoKeys = Object.keys(item.attributes).filter((key) =>
+  getVideos = ({ attributes, startDateTime, attributeValues }) => {
+    const videoKeys = Object.keys(attributes).filter((key) =>
       this.attributeIsVideo({
         key,
-        attributeValues: item.attributeValues,
-        attributes: item.attributes,
+        attributeValues,
+        attributes,
       })
     );
-    // console.log("Full Video", item.attributeValues?.fullLengthVideoEmbed?.value, "Short Video", item.attributeValues?.videoEmbed?.value)
-    return videoKeys.map((key) => ({
+    const keysByDate = videoKeys.filter(
+      isThisWeek(new Date(startDateTime))
+        ? (key) => key === 'fullLengthVideoEmbed'
+        : (key) => key === 'videoEmbed'
+    );
+    const keys = keysByDate.map((key) => ({
       __typename: 'VideoMedia',
       key,
-      name: item.attributes?.key?.name,
-      embedHtml: isThisWeek(new Date(startDate))
-        ? item.attributeValues?.fullLengthVideoEmbed?.value ||
-          item.attributeValues?.key?.value
-        : item.attributeValues?.key?.value,
-      sources: item.attributeValues?.key?.value
+      name: attributes[key].name,
+      embedHtml: attributeValues[key].value,
+      sources: attributeValues[key].value
         ? [
             {
-              uri: item.attributeValues?.key?.value,
+              uri: attributeValues[key].value,
             },
           ]
         : [],
     }));
+    return keys;
   };
 
   byTaggedContent = async (tag) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7139,6 +7139,11 @@ date-fns@^2.0.1:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.16.1.tgz#05775792c3f3331da812af253e1a935851d3834b"
   integrity sha512-sAJVKx/FqrLYHAQeN7VpJrPhagZc9R4ImZIWYRFZaaohR3KzmuK88touwsSwSVT8Qcbd4zoDsnGfX4GFB4imyQ==
 
+date-fns@^2.24.0:
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.24.0.tgz#7d86dc0d93c87b76b63d213b4413337cfd1c105d"
+  integrity sha512-6ujwvwgPID6zbI0o7UbURi2vlLDR9uP26+tW6Lg+Ji3w7dd0i3DOcjcClLjLPranT60SSEFBwdSyYwn/ZkPIuw==
+
 dateformat@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"


### PR DESCRIPTION
This change allows the church to use different videos, one for this week, and one for all other weeks. Chase Oaks is using this to display a full length video (sermon and worship) for the first week a content item is live, then switch to a short video (sermon only) after the first week.

This was tested via graphql query and visually in the simulator.

In this image, you can see that the top request functions properly based on the date on each request as well as what key is returned from the array. The top item is "this week" and the bottom item is "not this week".
![Screen Shot 2021-10-01 at 9 12 05 AM](https://user-images.githubusercontent.com/72768221/135637062-8382b966-59e8-4cc6-a75e-50d9f0ad692f.png)


