### PR TITLE
chore: specified a ndk version for android

### DIFF
--- a/apolloschurchapp/android/build.gradle
+++ b/apolloschurchapp/android/build.gradle
@@ -6,6 +6,7 @@ buildscript {
         minSdkVersion = 21
         compileSdkVersion = 29
         targetSdkVersion = 29
+        ndkVersion = "20.1.5948944"
     }
     repositories {
         google()


### PR DESCRIPTION
This is in to fix android deploys. Will watch the deploys to see if it solves the issue and can implement to other apps if so.

Is there a way to test this locally without pushing to master? I was able to build in Android Studio just fine.

https://github.com/microsoft/appcenter/issues/2144