### PR TITLE
chore: downgrade ndk version again

### DIFF
--- a/apolloschurchapp/android/build.gradle
+++ b/apolloschurchapp/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         minSdkVersion = 21
         compileSdkVersion = 29
         targetSdkVersion = 29
-        ndkVersion = "20.1.5948944"
+        ndkVersion = "18.1.5063045"
     }
     repositories {
         google()


### PR DESCRIPTION
This PR is trying to solve the problem with Android deploys that are failing for several Apollos apps.

This error message suggested the version in this PR.
<img width="1360" alt="Screen Shot 2021-10-01 at 2 23 33 PM" src="https://user-images.githubusercontent.com/72768221/135691651-defb613a-ff69-41f5-a0c7-10cc7bd9f9ec.png">

Tested it by building it local.
![Screen Shot 2021-10-01 at 5 10 17 PM](https://user-images.githubusercontent.com/72768221/135691683-334405f1-7c8c-48b8-8370-8f40867a3cf3.png)

