### PR TITLE
bumped cfbundle version for OneSignal and App

### DIFF
--- a/apolloschurchapp/ios/ChaseOaks.xcodeproj/project.pbxproj
+++ b/apolloschurchapp/ios/ChaseOaks.xcodeproj/project.pbxproj
@@ -938,7 +938,7 @@
 				);
 				INFOPLIST_FILE = ChaseOaks/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 6.3.0;
+				MARKETING_VERSION = 6.4.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -973,7 +973,7 @@
 				);
 				INFOPLIST_FILE = ChaseOaks/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 6.3.0;
+				MARKETING_VERSION = 6.4.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -1143,7 +1143,7 @@
 				INFOPLIST_FILE = OneSignalNotificationServiceExtension/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				MARKETING_VERSION = 6.3.0;
+				MARKETING_VERSION = 6.4.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.subsplashconsulting.RNV2KH.OneSignalNotificationServiceExtension;
@@ -1177,7 +1177,7 @@
 				INFOPLIST_FILE = OneSignalNotificationServiceExtension/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				MARKETING_VERSION = 6.3.0;
+				MARKETING_VERSION = 6.4.0;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.subsplashconsulting.RNV2KH.OneSignalNotificationServiceExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
This PR addresses this error message in the latest commit to the repo and bumps the versions of OneSignal as well as the app.

<img width="1411" alt="Screen Shot 2021-10-04 at 8 38 41 AM" src="https://user-images.githubusercontent.com/72768221/135861539-1cfaca96-cbb5-4368-9b63-d1d0d8c59673.png">
