### PR TITLE
chore: fixed Tab enum and new FeatureFeedTab

### DIFF
--- a/apollos-church-api/src/data/FeatureFeed.js
+++ b/apollos-church-api/src/data/FeatureFeed.js
@@ -3,18 +3,6 @@ import gql from 'graphql-tag';
 
 const { dataSource, resolver } = FeatureFeed;
 
-// const resolver = {
-//   ...FeatureFeed.resolver,
-//   Query: {
-//     ...FeatureFeed.resolver.Query,
-//     tvFeedFeatures: (root, args, { dataSources }) =>
-//       dataSources.FeatureFeed.getFeed({
-//         type: 'apollosConfig',
-//         args: { section: 'TV_FEATURES', ...args },
-//       }),
-//   },
-// };
-
 const schema = gql`
   extend enum Tab {
     TV

--- a/apollos-church-api/src/data/FeatureFeed.js
+++ b/apollos-church-api/src/data/FeatureFeed.js
@@ -1,19 +1,19 @@
 import { FeatureFeed } from '@apollosproject/data-connector-rock';
 import gql from 'graphql-tag';
 
-const { dataSource } = FeatureFeed;
+const { dataSource, resolver } = FeatureFeed;
 
-const resolver = {
-  ...FeatureFeed.resolver,
-  Query: {
-    ...FeatureFeed.resolver.Query,
-    tvFeedFeatures: (root, args, { dataSources }) =>
-      dataSources.FeatureFeed.getFeed({
-        type: 'apollosConfig',
-        args: { section: 'TV_FEATURES', ...args },
-      }),
-  },
-};
+// const resolver = {
+//   ...FeatureFeed.resolver,
+//   Query: {
+//     ...FeatureFeed.resolver.Query,
+//     tvFeedFeatures: (root, args, { dataSources }) =>
+//       dataSources.FeatureFeed.getFeed({
+//         type: 'apollosConfig',
+//         args: { section: 'TV_FEATURES', ...args },
+//       }),
+//   },
+// };
 
 const schema = gql`
   extend enum Tab {

--- a/apollos-church-api/src/data/index.js
+++ b/apollos-church-api/src/data/index.js
@@ -28,7 +28,7 @@ import {
   Campus,
   Group,
   Feature,
-  FeatureFeed,
+  // FeatureFeed,
   ActionAlgorithm,
   Event,
   PrayerRequest,
@@ -49,6 +49,7 @@ import * as OneSignalWithRock from './oneSignalWithRock';
 // This is to mock any postgres resolvers so we don't throw API errors for unresolved
 // typedefs
 import NoPostgres from './noPostgres';
+import FeatureFeed from './FeatureFeed';
 
 const data = {
   Interfaces,

--- a/apollos-church-api/src/data/index.postgres.js
+++ b/apollos-church-api/src/data/index.postgres.js
@@ -24,7 +24,7 @@ import {
   AuthSms,
   Group,
   BinaryFiles,
-  FeatureFeed,
+  // FeatureFeed,
   Event,
   PrayerRequest,
   Person as RockPerson,
@@ -61,6 +61,7 @@ import * as Video from './Video';
 import * as RockContentItem from './ContentItem';
 import * as RockActionAlgorithm from './ActionAlgorithm';
 import * as Cloudinary from './cloudinary';
+import * as FeatureFeed from './FeatureFeed';
 
 // This modules ties together certain updates so they occurs in both Rock and Postgres.
 // Will be eliminated in the future through an enhancement to the Shovel


### PR DESCRIPTION
The FeatureFeed import in the api got missed in a previous merge. This fixes that.

But, I would also like to get some input on why extending the Tab enum in FeatureFeed.js is not working correctly (even with this import fix). Let's not merge this until we figure that out as well and commit the changes here