### PR TITLE
chore: added view all to content channels on watch tab

### DIFF
--- a/apollos-church-api/config.yml
+++ b/apollos-church-api/config.yml
@@ -199,6 +199,7 @@ TABS:
       title: All Series
       primaryAction:
         action: OPEN_CHANNEL
+        title: 'View All'
         relatedNode:
           __typename: ContentChannel
           id: 22
@@ -213,6 +214,7 @@ TABS:
       title: Groups
       primaryAction:
         action: OPEN_CHANNEL
+        title: 'View All'
         relatedNode:
           __typename: ContentChannel
           id: 392
@@ -227,6 +229,7 @@ TABS:
       title: Worship
       primaryAction:
         action: OPEN_CHANNEL
+        title: 'View All'
         relatedNode:
           __typename: ContentChannel
           id: 383
@@ -241,6 +244,7 @@ TABS:
       title: Kids
       primaryAction:
         action: OPEN_CHANNEL
+        title: 'View All'
         relatedNode:
           __typename: ContentChannel
           id: 395
@@ -255,6 +259,7 @@ TABS:
       title: En Español
       primaryAction:
         action: OPEN_CHANNEL
+        title: 'View All'
         relatedNode:
           __typename: ContentChannel
           id: 393


### PR DESCRIPTION
Adds missing titles to primaryAction on Watch tab channels. Confirmed that the correct channel is being displayed on click.

https://user-images.githubusercontent.com/72768221/141204066-f595ae52-b560-4f06-8e94-158f0e56a581.mp4


