### PR TITLE
chore: bump sdk version to 30

### DIFF
--- a/apolloschurchapp/android/build.gradle
+++ b/apolloschurchapp/android/build.gradle
@@ -4,8 +4,8 @@ buildscript {
     ext {
         buildToolsVersion = "29.0.2"
         minSdkVersion = 21
-        compileSdkVersion = 29
-        targetSdkVersion = 29
+        compileSdkVersion = 30
+        targetSdkVersion = 30
         ndkVersion = "18.1.5063045"
     }
     repositories {


### PR DESCRIPTION
This PR bumps the SDK version to 30 to fix this deploy error:
<img width="654" alt="Screen Shot 2021-11-15 at 3 35 52 PM" src="https://user-images.githubusercontent.com/72768221/141857150-3b96bd17-ae57-44fd-a9cf-9a55db0cd022.png">

