### PR TITLE
feat: new 40 Day Challenge Content channel

### DIFF
--- a/apollos-church-api/config.yml
+++ b/apollos-church-api/config.yml
@@ -163,6 +163,14 @@ TABS:
           arguments:
             limit: 1
             channelIds:
+              - 426
+      title: 40 Day Challenge
+      type: VerticalCardList
+    - algorithms:
+        - type: CONTENT_FEED
+          arguments:
+            limit: 1
+            channelIds:
               - 363
       title: Daily Scripture
       type: VerticalCardList

--- a/apollos-church-api/config.yml
+++ b/apollos-church-api/config.yml
@@ -166,6 +166,15 @@ TABS:
               - 426
       title: 40 Day Challenge
       type: VerticalCardList
+    - title: This Week # This pulls the 7 content items for 40 Day Challenge this week
+      subtitle: 40 Day Challenge
+      algorithms:
+        - type: WEEKLY_CONTENT_FEED
+          arguments:
+            channelIds:
+              - 426
+      type: ActionList
+      isCard: false
     - algorithms:
         - type: CONTENT_FEED
           arguments:


### PR DESCRIPTION
- chore: added new 40 day challenge
- feat: added new weekly channel to home tab

This PR adds 2 content channels to the Home tab. One is a single content item that is the current day's 40 Day Challenge item. The other is all of the 40 Day Challenge items for this week from Sunday to Saturday. This was tested on iPhone, iPad, and Android.

https://user-images.githubusercontent.com/72768221/149385168-2bf74fc2-1d17-4781-b6b4-3292cb692364.mp4


