### PR TITLE
chore: attempt to fix android deploys

### DIFF
--- a/apolloschurchapp/android/app/build.gradle
+++ b/apolloschurchapp/android/app/build.gradle
@@ -93,7 +93,6 @@ project.ext.react = [
 ]
 
 apply from: "../../node_modules/react-native/react.gradle"
-apply plugin: "com.bugsnag.android.gradle"
 
 /**
  * Set this to true to create two separate APKs instead of one:
@@ -132,24 +131,25 @@ def jscFlavor = 'org.webkit:android-jsc:+'
 def enableHermes = project.ext.react.get("enableHermes", true);
 
 /**
- * Trying to fix Hermes:
- * https://github.com/facebook/react-native/issues/26400#issuecomment-539395814
+ * Architectures to build native code for in debug.
  */
-configurations.all {
-  resolutionStrategy {
-    force "com.facebook.soloader:soloader:0.8.2"
-  }
-}
+def nativeArchitectures = project.getProperties().get("reactNativeDebugArchitectures")
+
 
 android {
-    ndkVersion rootProject.ext.ndkVersion
-    
-    compileSdkVersion rootProject.ext.compileSdkVersion
-
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+    // workaround fixing a couple of RN Android libraries that jumped the gun
+    // https://stackoverflow.com/questions/69208613/getting-error-while-running-react-native-app
+    configurations.all {
+        resolutionStrategy {
+            force "androidx.work:work-runtime-ktx:2.6.0"
+            force "androidx.work:work-runtime:2.6.0"
+            force 'androidx.browser:browser:1.2.0'
+        }
     }
+
+    ndkVersion rootProject.ext.ndkVersion
+
+    compileSdkVersion rootProject.ext.compileSdkVersion
 
     defaultConfig {
         applicationId "com.chaseoaks.churchapp"
@@ -180,6 +180,14 @@ android {
         }
     }
     buildTypes {
+        debug {
+            signingConfig signingConfigs.debug
+            if (nativeArchitectures) {
+                ndk {
+                    abiFilters nativeArchitectures.split(',')
+                }
+            }
+        }
         release {
             minifyEnabled enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
@@ -209,7 +217,7 @@ dependencies {
 
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"
     debugImplementation("com.facebook.flipper:flipper:${FLIPPER_VERSION}") {
-      exclude group:'com.facebook.fbjni'
+        exclude group:'com.facebook.fbjni'
     }
     debugImplementation("com.facebook.flipper:flipper-network-plugin:${FLIPPER_VERSION}") {
         exclude group:'com.facebook.flipper'
@@ -231,13 +239,9 @@ dependencies {
 // Run this once to be able to run the application with BUCK
 // puts all compile dependencies into folder libs for BUCK to use
 task copyDownloadableDepsToLibs(type: Copy) {
-    from configurations.compile
+    from configurations.implementation
     into 'libs'
 }
 
 
 apply from: file("../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesAppBuildGradle(project)
-
-bugsnag {
-  uploadReactNativeMappings = true
-}

--- a/apolloschurchapp/android/build.gradle
+++ b/apolloschurchapp/android/build.gradle
@@ -2,20 +2,19 @@
 
 buildscript {
     ext {
-        buildToolsVersion = "29.0.2"
+        buildToolsVersion = "30.0.2"
         minSdkVersion = 21
+
         compileSdkVersion = 30
         targetSdkVersion = 30
-        ndkVersion = "18.1.5063045"
+        ndkVersion = "21.4.7075529"
     }
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:3.5.3")
-        classpath("com.bugsnag:bugsnag-android-gradle-plugin:5.+")
-
+        classpath("com.android.tools.build:gradle:4.2.2")
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
@@ -23,9 +22,8 @@ buildscript {
 
 allprojects {
     repositories {
+        mavenCentral()
         mavenLocal()
-        google()
-        jcenter()
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
             url("$rootDir/../node_modules/react-native/android")
@@ -34,6 +32,16 @@ allprojects {
             // Android JSC is installed from npm
             url("$rootDir/../node_modules/jsc-android/dist")
         }
-        maven { url "https://jitpack.io" }
+        google()
+        maven { url 'https://www.jitpack.io' }
+        // bug in react-native-video, needs jcenter
+        // https://github.com/react-native-video/react-native-video/issues/2468
+        jcenter() {
+            content {
+                includeModule("com.yqritc", "android-scalablevideoview")
+                includeModule("com.facebook.yoga", "proguard-annotations")
+                includeModule("com.facebook.fbjni", "fbjni-java-only")
+            }
+        }
     }
 }

--- a/apolloschurchapp/android/gradle.properties
+++ b/apolloschurchapp/android/gradle.properties
@@ -16,4 +16,4 @@ android.useAndroidX=true
 org.gradle.jvmargs=-Xmx1536M -Dkotlin.daemon.jvm.options\="-Xmx1536M"
 
 # Version of flipper SDK to use with React Native
-FLIPPER_VERSION=0.37.0
+FLIPPER_VERSION=0.99.0

--- a/apolloschurchapp/android/gradle/wrapper/gradle-wrapper.properties
+++ b/apolloschurchapp/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.2-all.zip


### PR DESCRIPTION
Steps for working local deploys (jury is still out on fastlane deploys):

- Upgrade these files to match the apollos-templates repo
  - android > build.gradle
  - android > app > build.gradle
  - android > gradle.properties
  - android > gradle > wrapper > gradle-wrapper.properties
- In android > build.gradle move this code to the bottom of allprojects
```
        jcenter() {
            content {
                includeModule("com.yqritc", "android-scalablevideoview")
                includeModule("com.facebook.yoga", "proguard-annotations")
                includeModule("com.facebook.fbjni", "fbjni-java-only")
            }
        }
```