### PR TITLE
40 day challenge adjustment

### DIFF
--- a/apollos-church-api/src/data/ActionAlgorithm.js
+++ b/apollos-church-api/src/data/ActionAlgorithm.js
@@ -5,9 +5,10 @@ import {
   formatISO,
   previousSunday,
   nextSaturday,
-  startOfToday,
   startOfTomorrow,
   endOfToday,
+  isSaturday,
+  endOfYesterday,
 } from 'date-fns';
 
 const { resolver } = ActionAlgorithm;
@@ -108,7 +109,7 @@ class dataSource extends ActionAlgorithm.dataSource {
   async weeklyContentFeedAlgorithm({
     category = '',
     channelIds = [],
-    limit = 5,
+    limit = 7,
     skip = 0,
   } = {}) {
     const { ContentItem } = this.context.dataSources;
@@ -124,7 +125,7 @@ class dataSource extends ActionAlgorithm.dataSource {
             `((StartDateTime gt datetime'${formatISO(
               previousSunday(startOfTomorrow())
             )}') and (StartDateTime lt datetime'${formatISO(
-              nextSaturday(endOfToday())
+              nextSaturday(isSaturday(endOfToday()) ? endOfYesterday() : endOfToday())
             )}'))`
           )
           .top(limit)

--- a/apollos-church-api/src/data/ActionAlgorithm.js
+++ b/apollos-church-api/src/data/ActionAlgorithm.js
@@ -6,8 +6,6 @@ import {
   previousSunday,
   nextSaturday,
   startOfTomorrow,
-  endOfToday,
-  isSaturday,
   endOfYesterday,
 } from 'date-fns';
 
@@ -125,7 +123,7 @@ class dataSource extends ActionAlgorithm.dataSource {
             `((StartDateTime gt datetime'${formatISO(
               previousSunday(startOfTomorrow())
             )}') and (StartDateTime lt datetime'${formatISO(
-              nextSaturday(isSaturday(endOfToday()) ? endOfYesterday() : endOfToday())
+              nextSaturday(endOfYesterday())
             )}'))`
           )
           .top(limit)


### PR DESCRIPTION
- Limit updated from 5 to 7
- Using `nextSaturday(endOfYesterday())` instead of `nextSaturday(endOfToday())` should ensure that the weekly content feed date range (Sun. through Sat., 7 days only) is observed.

### **Before Change**
_Incorrect range, System date/time set to 01/22/2022:_
<img width="1728" alt="Screen Shot 2022-01-22 at 9 16 41 PM" src="https://user-images.githubusercontent.com/19194337/151029072-2df321c5-490d-4c6e-b04b-bcb9635bdc27.png">

### **After Change**
_Correct range, System date/time set to 01/22/2022:_
<img width="1728" alt="Screen Shot 2022-01-20 at 9 07 47 PM" src="https://user-images.githubusercontent.com/19194337/151028108-5eea7ca6-b31c-44a8-98cc-9a71372c425e.png">

_Correct range, System date/time set to 01/29/2022:_
<img width="1728" alt="Screen Shot 2022-01-29 at 9 09 03 PM" src="https://user-images.githubusercontent.com/19194337/151028414-22e06d63-5675-46b7-a926-8e6598137e6a.png">